### PR TITLE
Add a read wake up the feather52 console.

### DIFF
--- a/ampy/pyboard.py
+++ b/ampy/pyboard.py
@@ -176,6 +176,9 @@ class Pyboard:
         # Brief delay before sending RAW MODE char if requests
         if _rawdelay > 0:
             time.sleep(_rawdelay)
+            
+        # An initial read seems required to wake the feather52 serial console.
+        self.read_until(1, b'\n', timeout=0.5)
 
         self.serial.write(b'\r\x03\x03') # ctrl-C twice: interrupt any running program
 


### PR DESCRIPTION
My Adafruit Feather nRF52 doesn't seem to wake up to the serial console connection until a read is performed.  Adding this fixes ampy for me.  (it is running the circuitpython 3.x branch from today under the 2.0.1 bootloader)