### PR TITLE
Allow downloading of arbitrary binary files

### DIFF
--- a/ampy/files.py
+++ b/ampy/files.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 import ast
 import textwrap
+import binascii
 
 from ampy.pyboard import PyboardError
 
@@ -58,12 +59,13 @@ class Files(object):
         # expects string data.
         command = """
             import sys
+            import ubinascii
             with open('{0}', 'rb') as infile:
                 while True:
                     result = infile.read({1})
                     if result == b'':
                         break
-                    len = sys.stdout.write(result)
+                    len = sys.stdout.write(ubinascii.hexlify(result))
         """.format(
             filename, BUFFER_SIZE
         )
@@ -81,7 +83,7 @@ class Files(object):
             except UnicodeDecodeError:
                 raise ex
         self._pyboard.exit_raw_repl()
-        return out
+        return binascii.unhexlify(out)
 
     def ls(self, directory="/", long_format=True, recursive=False):
         """List the contents of the specified directory (or root if none is

--- a/ampy/files.py
+++ b/ampy/files.py
@@ -73,9 +73,12 @@ class Files(object):
         except PyboardError as ex:
             # Check if this is an OSError #2, i.e. file doesn't exist and
             # rethrow it as something more descriptive.
-            if ex.args[2].decode("utf-8").find("OSError: [Errno 2] ENOENT") != -1:
-                raise RuntimeError("No such file: {0}".format(filename))
-            else:
+            try:
+                if ex.args[2].decode("utf-8").find("OSError: [Errno 2] ENOENT") != -1:
+                    raise RuntimeError("No such file: {0}".format(filename))
+                else:
+                    raise ex
+            except UnicodeDecodeError:
                 raise ex
         self._pyboard.exit_raw_repl()
         return out


### PR DESCRIPTION
Fixes a small issue when attempting to read errors from getting a file.  The response is always unicode decoded and this fails if particular bytes are in the stream.  We also hexlify encode (as the simplest encoding mechanism) all file transfers, to ensure no binary characters are ever sent.  This doubles the amount of data that must be transferred for each file download, but does ensure arbitrary data can be downloaded.  This should resolve issue #45.

I believe that `ubinascii` is a standard library for micropython, but if not this will fail when downloading files.  So this might need some cleaning up before prime-time, but I'm not familiar enough with micropython to know what ascii-safe encoding schemes are available in micropython (base64 does not appear to be in certain distributions).  