### PR TITLE
The put method should update existing folder contents

### DIFF
--- a/ampy/cli.py
+++ b/ampy/cli.py
@@ -246,14 +246,15 @@ def put(local, remote):
             try:
                 # Create remote parent directory.
                 board_files.mkdir(remote_parent)
-                # Loop through all the files and put them on the board too.
-                for filename in child_files:
-                    with open(os.path.join(parent, filename), "rb") as infile:
-                        remote_filename = posixpath.join(remote_parent, filename)
-                        board_files.put(remote_filename, infile.read())
             except files.DirectoryExistsError:
                 # Ignore errors for directories that already exist.
                 pass
+            # Loop through all the files and put them on the board too.
+            for filename in child_files:
+                with open(os.path.join(parent, filename), "rb") as infile:
+                    remote_filename = posixpath.join(remote_parent, filename)
+                    board_files.put(remote_filename, infile.read())
+
 
     else:
         # File copy, open the file and copy its contents to the board.


### PR DESCRIPTION
**Problem**:
When the cli put method receives a folder that already exists on the target board it completely skips that folder.
This makes updating projects with multiple sub-folders a pain.

**Proposed solution**
In this pull request when a folder is passed to the put method the files.DirectoryExistsError does not prevent the copy/overwrite action of the child files. Thus the folder contents are updated. Also:
- The update action is implied in the original method description. 
- When the same method is used with single files it already does an update action